### PR TITLE
Fix: Resolve ESLint errors in doctor section

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "@emotion/styled": "^11.14.0",
         "@faker-js/faker": "^9.8.0",
         "@iconify/react": "^6.0.0",
+        "@mui/icons-material": "^5.17.1",
         "@mui/lab": "^5.0.0-alpha.176",
         "@mui/material": "^5.17.1",
         "@mui/system": "^7.1.1",

--- a/src/sections/doctor/DoctorPhoneNumbers.jsx
+++ b/src/sections/doctor/DoctorPhoneNumbers.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useState, useCallback } from 'react'; // Added useCallback
 
 // MUI components for list and text display/input
-import { List, ListItem, TextField, Typography, ListItemText, Box } from '@mui/material';
+import { Box, List, ListItem, TextField, Typography, ListItemText } from '@mui/material';
 
 // Component to display and edit a list of phone numbers
 const DoctorPhoneNumbers = ({
@@ -83,7 +83,7 @@ const DoctorPhoneNumbers = ({
                             }}
                             // Display error state and helper text if there's an error for this index.
                             error={!!errors[index]}
-                            helperText={errors[index] || ' '} {/* Show space to maintain layout even if no error */}
+                            helperText={errors[index] || ' '}
                             inputProps={{
                                 maxLength: 13, // HTML5 attribute to limit input length
                                 type: 'tel', // Use type="tel" for semantic phone number input
@@ -148,7 +148,6 @@ DoctorPhoneNumbers.propTypes = {
 DoctorPhoneNumbers.defaultProps = {
     onPhoneNumberChange: () => {}, // No-op function if not provided
     isEditing: false, // Default to view mode
-    phoneNumbers: [], // Default to an empty array if not provided
 };
 
 export default DoctorPhoneNumbers;


### PR DESCRIPTION
This commit addresses several ESLint issues:

1.  Installed the missing `@mui/icons-material` package to resolve `import/no-unresolved` for `DeleteIcon` in `DoctorAvailability.jsx`.
2.  Fixed a parsing error in `DoctorPhoneNumbers.jsx` caused by a malformed JSX comment within a `TextField` component's `helperText` prop.
3.  Corrected a `react/default-props-match-prop-types` error in `DoctorPhoneNumbers.jsx` by removing the `phoneNumbers` default prop since it's marked as `isRequired`.

ESLint now runs without errors or warnings across the project.